### PR TITLE
Fixed item pickup logic

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -12,13 +12,15 @@ let STATS = {
 		"BASE_HP":20,
 		"HP":6,
 		"DEF":5,
-		"ATK":3
+		"ATK":3,
+		"SHARDS":0
 	},
 	"Maxion": {
 		"BASE_HP":18,
 		"HP":18,
 		"DEF":8,
-		"ATK":8
+		"ATK":8,
+		"SHARDS":0
 	}
 }
 		


### PR DESCRIPTION
-now player can pick up shards on square where monsters were defeated that turn, as intended
-monsters can now pick up shards if the walk over them while pathing to the player; the player gets any shards a monster is holding when it dies